### PR TITLE
docs(chart-value-examples): add plugins example using curl init container

### DIFF
--- a/chart-value-examples/plugins/README.md
+++ b/chart-value-examples/plugins/README.md
@@ -27,7 +27,7 @@ release tag — avoid `latest` so deployments are reproducible.
 - The plugin `.lke` files are persisted on the `lke-data` PVC. Re-running the
   init container on pod restart is idempotent (curl overwrites the file with
   the same content).
-- The init container inherits the chart's default non-root `podSecurityContext`
-  (`2013:2013`); `curlimages/curl` supports running as an arbitrary UID.
+- The init container inherits the chart's pod-level `podSecurityContext`
+  (`runAsUser: 2013`, `fsGroup: 2000`, `seccompProfile: RuntimeDefault`); `curlimages/curl` supports running as an arbitrary UID.
 - If your cluster has no outbound internet access, pre-stage the plugin
   artifacts in an internal registry / object store and adjust the URL.

--- a/chart-value-examples/plugins/README.md
+++ b/chart-value-examples/plugins/README.md
@@ -1,8 +1,8 @@
 # Installing Linkurious Enterprise plugins via an init container
 
 The sibling [values.yaml](values.yaml) file provides an example of installing
-Linkurious Enterprise plugins by downloading their release archives into
-`/data/plugins` using a `curl`-based init container.
+Linkurious Enterprise plugins by downloading their release assets (the `.lke`
+files) into `/data/plugins` using a `curl`-based init container.
 
 This example downloads the [`lke-plugin-third-party-data`](https://github.com/Linkurious/lke-plugin-third-party-data)
 plugin release from GitHub.

--- a/chart-value-examples/plugins/README.md
+++ b/chart-value-examples/plugins/README.md
@@ -1,0 +1,33 @@
+# Installing Linkurious Enterprise plugins via an init container
+
+The sibling [values.yaml](values.yaml) file provides an example of installing
+Linkurious Enterprise plugins by downloading their release archives into
+`/data/plugins` using a `curl`-based init container.
+
+This example downloads the [`lke-plugin-third-party-data`](https://github.com/Linkurious/lke-plugin-third-party-data)
+plugin release from GitHub.
+
+## How it works
+
+The chart exposes `initContainers` (see [values.yaml](../../charts/linkurious-enterprise/values.yaml)),
+which lets you run arbitrary containers before the main Linkurious Enterprise
+container starts. The init container mounts the same `lke-data` PVC that the
+main container uses at `/data`, downloads the plugin `.lke` file into
+`/data/plugins`, and exits. Linkurious Enterprise then loads the plugin at
+startup (`plugins.enabled: true`).
+
+## Adding more plugins
+
+Append additional `curl` commands to the init container `args` block, one per
+plugin, all writing under `/data/plugins`. Pin each plugin to a specific
+release tag — avoid `latest` so deployments are reproducible.
+
+## Notes
+
+- The plugin `.lke` files are persisted on the `lke-data` PVC. Re-running the
+  init container on pod restart is idempotent (curl overwrites the file with
+  the same content).
+- The init container inherits the chart's default non-root `podSecurityContext`
+  (`2013:2013`); `curlimages/curl` supports running as an arbitrary UID.
+- If your cluster has no outbound internet access, pre-stage the plugin
+  artifacts in an internal registry / object store and adjust the URL.

--- a/chart-value-examples/plugins/values.yaml
+++ b/chart-value-examples/plugins/values.yaml
@@ -23,7 +23,14 @@ plugins:
 initContainers:
   - name: download-plugins
     image: curlimages/curl:8.10.1
-    # The default podSecurityContext (runAsUser/runAsGroup 2013) is inherited.
+    # Inherit the chart's default podSecurityContext (runAsUser/runAsGroup 2013).
+    # Mirror the chart's default container securityContext so cluster
+    # admission policies (e.g. Kyverno restricted baseline) accept the pod.
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
     command: ['sh', '-c']
     args:
       - |

--- a/chart-value-examples/plugins/values.yaml
+++ b/chart-value-examples/plugins/values.yaml
@@ -23,7 +23,7 @@ plugins:
 initContainers:
   - name: download-plugins
     image: curlimages/curl:8.10.1
-    # Inherit the chart's default podSecurityContext (runAsUser/runAsGroup 2013).
+    # Inherit the chart's default podSecurityContext (runAsUser: 2013, fsGroup: 2000, seccompProfile: RuntimeDefault).
     # Mirror the chart's default container securityContext so cluster
     # admission policies (e.g. Kyverno restricted baseline) accept the pod.
     securityContext:

--- a/chart-value-examples/plugins/values.yaml
+++ b/chart-value-examples/plugins/values.yaml
@@ -1,0 +1,50 @@
+image:
+  # -- Repository to use for the application.
+  # You will need to retrieve the image from the Linkurious Customer Center and load it into your private repository
+  repository: ""
+
+configOverlayEnabled: false
+metrics:
+  prometheus:
+    enabled: false
+
+plugins:
+  enabled: true
+
+## -- Download Linkurious plugins into /data/plugins using an init container.
+## The lke-data volume is shared with the main container, so plugins dropped
+## into /data/plugins by the init container are picked up at startup.
+##
+## This example downloads the lke-plugin-third-party-data plugin release
+## from GitHub: https://github.com/Linkurious/lke-plugin-third-party-data
+##
+## To add more plugins, append additional curl commands to the args block
+## (one -o per plugin, all writing under /data/plugins).
+initContainers:
+  - name: download-plugins
+    image: curlimages/curl:8.10.1
+    # The default podSecurityContext (runAsUser/runAsGroup 2013) is inherited.
+    command: ['sh', '-c']
+    args:
+      - |
+        set -eu
+        mkdir -p /data/plugins
+        echo "Downloading lke-plugin-third-party-data ${PLUGIN_THIRD_PARTY_DATA_VERSION}..."
+        curl --fail --location --retry 3 --retry-delay 5 \
+          -o "/data/plugins/lke-plugin-third-party-data-${PLUGIN_THIRD_PARTY_DATA_VERSION}.lke" \
+          "https://github.com/Linkurious/lke-plugin-third-party-data/releases/download/${PLUGIN_THIRD_PARTY_DATA_VERSION}/lke-plugin-third-party-data-${PLUGIN_THIRD_PARTY_DATA_VERSION}.lke"
+        echo "Plugins available in /data/plugins:"
+        ls -l /data/plugins
+    env:
+      - name: PLUGIN_THIRD_PARTY_DATA_VERSION
+        value: v1.0.7
+    volumeMounts:
+      - mountPath: /data
+        name: lke-data
+
+## -- Persistent storage is strongly recommended so downloaded plugins survive pod restarts.
+persistentVolume:
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 5Gi


### PR DESCRIPTION
## Summary

Adds a new example under `chart-value-examples/plugins/` showing how to install Linkurious Enterprise plugins by downloading their release archives into `/data/plugins` via a `curl`-based `initContainer`.

Uses [`lke-plugin-third-party-data`](https://github.com/Linkurious/lke-plugin-third-party-data) v1.0.7 as the example release.

## How it works

The chart already exposes `initContainers` in values. The init container mounts the shared `lke-data` PVC at `/data`, downloads the plugin `.lke` file into `/data/plugins`, then exits. Linkurious Enterprise picks it up at startup (`plugins.enabled: true`).

## Files

- `chart-value-examples/plugins/values.yaml` — example values
- `chart-value-examples/plugins/README.md` — pattern explanation

## Verification

`helm template` renders cleanly with the example values. No chart template/values changes, so no `Chart.yaml` bump.