### PR TITLE
Set OTLP protocol env var when OpenTelemetry is enabled

### DIFF
--- a/charts/linkurious-enterprise/Chart.yaml
+++ b/charts/linkurious-enterprise/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/linkurious-enterprise/templates/statefulset.yaml
+++ b/charts/linkurious-enterprise/templates/statefulset.yaml
@@ -85,6 +85,12 @@ spec:
             {{- toYaml .Values.env | nindent 12 }}
             {{- end }}
             {{- if .Values.openTelemetry.enabled }}
+            {{- $hasOtlpProtocol := false }}
+            {{- range $env := (default (list) .Values.env) }}
+            {{- if eq (get $env "name") "OTEL_EXPORTER_OTLP_PROTOCOL" }}
+            {{- $hasOtlpProtocol = true }}
+            {{- end }}
+            {{- end }}
             - name: LKE_OTEL_ENABLED
               value: "true"
             - name: OTEL_METRICS_EXPORTER
@@ -95,7 +101,7 @@ spec:
               value: {{ .Values.openTelemetry.traces.sampler | quote }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ .Values.openTelemetry.traces.samplerArg | quote }}
-            {{- if not (has "OTEL_EXPORTER_OTLP_PROTOCOL" (pluck "name" (default (list) .Values.env))) }}
+            {{- if not $hasOtlpProtocol }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: {{ default "http/protobuf" .Values.openTelemetry.otlpProtocol | quote }}
             {{- end }}

--- a/charts/linkurious-enterprise/templates/statefulset.yaml
+++ b/charts/linkurious-enterprise/templates/statefulset.yaml
@@ -95,8 +95,10 @@ spec:
               value: {{ .Values.openTelemetry.traces.sampler | quote }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ .Values.openTelemetry.traces.samplerArg | quote }}
+            {{- if not (has "OTEL_EXPORTER_OTLP_PROTOCOL" (pluck "name" (default (list) .Values.env))) }}
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: "http/protobuf"
+              value: {{ default "http/protobuf" .Values.openTelemetry.otlpProtocol | quote }}
+            {{- end }}
             {{- end }}
             {{- if and .Values.ingress.enabled .Values.ingress.hosts }}
             - name: LKE_PUBLIC_PORT_HTTPS

--- a/charts/linkurious-enterprise/templates/statefulset.yaml
+++ b/charts/linkurious-enterprise/templates/statefulset.yaml
@@ -95,6 +95,8 @@ spec:
               value: {{ .Values.openTelemetry.traces.sampler | quote }}
             - name: OTEL_TRACES_SAMPLER_ARG
               value: {{ .Values.openTelemetry.traces.samplerArg | quote }}
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
             {{- end }}
             {{- if and .Values.ingress.enabled .Values.ingress.hosts }}
             - name: LKE_PUBLIC_PORT_HTTPS


### PR DESCRIPTION
Add OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf to the StatefulSet env vars when openTelemetry.enabled is true.