### PR TITLE
Allow Templating for Init Containers

### DIFF
--- a/charts/linkurious-enterprise/templates/statefulset.yaml
+++ b/charts/linkurious-enterprise/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           {{- toYaml .Values.backup.litestream.resources | nindent 12 }}
       {{- end }}
       {{- if .Values.initContainers }}
-        {{- toYaml .Values.initContainers | nindent 8 }}
+        {{- tpl (toYaml .Values.initContainers) $ | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
I had a brief chat about this with a colleague from Linkurious yesterday. He mentioned that the team is generally open to receive pull requests. Let me know if I need to follow other guidance to contribute 😊

**Problem Statement**

In our deployment we're looking to follow the init container pattern suggested in the [examples](https://github.com/Linkurious/docker-lke/tree/develop/chart-value-examples/plugins) to copy our plugins to the Linkurious installation. Our deployment has multiple stages (test, integration, production, ...). We're maintaining a common values file for all environments and specific values files for individual stages with only the differences.

For a clean setup, it would be useful to allow templating in the init container section, so we don't need to define the full init container specification for each individual stage, asHelm does not merge lists. In this example we're using a custom Docker image to ship the plugins, but the general issue remains the same if the plugins are pulled via a different mechanism.

```yaml
# This is part of the common values file
initContainers:
    - name: copy-plugins
      image: "some-custom-image:{{ .Values.someCustomImage.tag }}"
      securityContext: ...
      command: ...
      args: ...
      volumeMounts: ....

# This is specific to the values files of individual stages
someCustomImage:
    tag: 1.0.0
```

**Solution**

Pass the _initContainers_ value through the _tpl_ function.

The same is already present for _envFrom_. We may decide to add the same to other values too.