### PR TITLE
docs(chart): add commented-out config examples from managed instances

### DIFF
--- a/charts/linkurious-enterprise/Chart.yaml
+++ b/charts/linkurious-enterprise/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/linkurious-enterprise/values.yaml
+++ b/charts/linkurious-enterprise/values.yaml
@@ -247,7 +247,7 @@ config:
   #   options:
   #     dialect: mysql
   #     host: "$ENV:LKE_DB_HOST"
-  #     port: "$ENV-NUMBER:LKE_DB_PORT"
+  #     port: "$ENV-NUMBER:LKE_DB_PORT" # numeric variable expansion
   #     storage: "$UNSET"
   #     dialectOptions:
   #       ssl:

--- a/charts/linkurious-enterprise/values.yaml
+++ b/charts/linkurious-enterprise/values.yaml
@@ -187,28 +187,31 @@ configOverlayEnabled: true
 # Ref: https://doc.linkurio.us/admin-manual/latest/configure/
 config:
   version: '{{ .Chart.AppVersion }}'
+  ## -- Unique key identifying this instance (used in cluster mode and config migration).
+  ## Typically set to "<namespace>.<release-name>".
+  # instanceKey: '{{ printf "%s.%s" .Release.Namespace .Release.Name }}'
+
+  ## -- Uncomment and configure server domain/origin (required behind ingress):
   server:
     cookieHttpOnly: true
     allowFraming: false
     useHttps: false
     forceHttps: false
-  ## -- Uncomment and configure server domain/origin (required behind ingress):
-  # server:
-  #   domain: "lke.example.com"
-  #   publicPortHttps: 443
-  #   forcePublicHttps: true
-  #   cookieSecure: true
-  #   allowOrigin:
-  #     - "https://lke.example.com"
-  #     # Wildcard pattern for all subdomains of the release namespace (templated):
-  #     # - '{{ printf "*.%s.example.com" .Release.Namespace }}'
-  #   trustedReverseProxies:
-  #     - uniquelocal
-  #     - 100.64.0.0/16
-  #   customHTTPHeaders:
-  #     Content-Security-Policy: >-
-  #       default-src 'self' 'unsafe-inline' blob: data:;
-  #       img-src 'self' blob: data:;
+    # domain: "lke.example.com"
+    # publicPortHttps: 443
+    # forcePublicHttps: true
+    # cookieSecure: true
+    # allowOrigin:
+    #   - "https://lke.example.com"
+    #   # Wildcard pattern for all subdomains of the release namespace (templated):
+    #   # - '{{ printf "*.%s.example.com" .Release.Namespace }}'
+    # trustedReverseProxies:
+    #   - uniquelocal
+    #   - 100.64.0.0/16
+    # customHTTPHeaders:
+    #   Content-Security-Policy: >-
+    #     default-src 'self' 'unsafe-inline' blob: data:;
+    #     img-src 'self' blob: data:;
   ## -- Uncomment and configure for SSO / OAuth2 (Azure AD example):
   # access:
   #   authRequired: true
@@ -264,7 +267,7 @@ config:
   #       alternativeEdgeId: uid
   #     index:
   #       vendor: neo4jSearch
-  ## -- Uncomment to enable obfuscation of sensitive data:
+  ## -- Uncomment to enable obfuscation of sensitive data in the UI:
   # advanced:
   #   obfuscation: true
   ## -- Uncomment to add basemap tile layers (Leaflet):
@@ -278,6 +281,25 @@ config:
   #     accessToken: null
   #     minZoom: 2
   #     maxZoom: 19
+  ## -- Uncomment to restrict features for trial / external-facing tiers:
+  # config:
+  #   hide: true
+  # alerts:
+  #   enabled: false
+  # entityResolution:
+  #   enabled: false
+  #   url: "https://er.linkurious.net"
+  # emailNotifications:
+  #   visualizationNotifications: true
+  # embeddedElasticSearch:
+  #   enabled: false
+  # license:
+  #   readOnly: true
+  # troubleshooting:
+  #   enableReport: false
+  #   enableFullErrors: false
+  # webhooks:
+  #   enabled: false
   ## -- Uncomment to configure plugins (csv-importer, data-table, image-export, etc.):
   # plugins:
   #   csv-importer:

--- a/charts/linkurious-enterprise/values.yaml
+++ b/charts/linkurious-enterprise/values.yaml
@@ -187,10 +187,6 @@ configOverlayEnabled: true
 # Ref: https://doc.linkurio.us/admin-manual/latest/configure/
 config:
   version: '{{ .Chart.AppVersion }}'
-  ## -- Unique key identifying this instance (used in cluster mode and config migration).
-  ## Typically set to "<namespace>.<release-name>".
-  # instanceKey: '{{ printf "%s.%s" .Release.Namespace .Release.Name }}'
-
   server:
     cookieHttpOnly: true
     allowFraming: false
@@ -268,7 +264,7 @@ config:
   #       alternativeEdgeId: uid
   #     index:
   #       vendor: neo4jSearch
-  ## -- Uncomment to enable obfuscation of sensitive data in the UI:
+  ## -- Uncomment to enable obfuscation of sensitive data:
   # advanced:
   #   obfuscation: true
   ## -- Uncomment to add basemap tile layers (Leaflet):
@@ -282,25 +278,6 @@ config:
   #     accessToken: null
   #     minZoom: 2
   #     maxZoom: 19
-  ## -- Uncomment to restrict features for trial / external-facing tiers:
-  # config:
-  #   hide: true
-  # alerts:
-  #   enabled: false
-  # entityResolution:
-  #   enabled: false
-  #   url: "https://er.linkurious.net"
-  # emailNotifications:
-  #   visualizationNotifications: true
-  # embeddedElasticSearch:
-  #   enabled: false
-  # license:
-  #   readOnly: true
-  # troubleshooting:
-  #   enableReport: false
-  #   enableFullErrors: false
-  # webhooks:
-  #   enabled: false
   ## -- Uncomment to configure plugins (csv-importer, data-table, image-export, etc.):
   # plugins:
   #   csv-importer:

--- a/charts/linkurious-enterprise/values.yaml
+++ b/charts/linkurious-enterprise/values.yaml
@@ -187,29 +187,135 @@ configOverlayEnabled: true
 # Ref: https://doc.linkurio.us/admin-manual/latest/configure/
 config:
   version: '{{ .Chart.AppVersion }}'
+  ## -- Unique key identifying this instance (used in cluster mode and config migration).
+  ## Typically set to "<namespace>.<release-name>".
+  # instanceKey: '{{ printf "%s.%s" .Release.Namespace .Release.Name }}'
+
   server:
     cookieHttpOnly: true
     allowFraming: false
     useHttps: false
     forceHttps: false
-  ## -- Uncomment and configure for SSO / OAuth2:
-  # access:
-  #   authRequired: true
-  #   oauth2:
-  #     enabled: true
-  #     provider: "azure"
-  #     authorizationURL: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize"
-  #     tokenURL: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token"
-  #     clientID: "<your-client-id>"
-  #     clientSecret: "<your-client-secret>"
-  #     azure:
-  #       tenantID: "<your-tenant-id>"
   ## -- Uncomment and configure server domain/origin (required behind ingress):
   # server:
   #   domain: "lke.example.com"
   #   publicPortHttps: 443
   #   forcePublicHttps: true
-  #   allowOrigin: "https://lke.example.com"
+  #   cookieSecure: true
+  #   allowOrigin:
+  #     - "https://lke.example.com"
+  #     # Wildcard pattern for all subdomains of the release namespace (templated):
+  #     # - '{{ printf "*.%s.example.com" .Release.Namespace }}'
+  #   trustedReverseProxies:
+  #     - uniquelocal
+  #     - 100.64.0.0/16
+  #   customHTTPHeaders:
+  #     Content-Security-Policy: >-
+  #       default-src 'self' 'unsafe-inline' blob: data:;
+  #       img-src 'self' blob: data:;
+  ## -- Uncomment and configure for SSO / OAuth2 (Azure AD example):
+  # access:
+  #   authRequired: true
+  #   disableLocalAuth: true
+  #   oauth2:
+  #     enabled: true
+  #     provider: "azure"                   # or "openidconnect"
+  #     authorizationURL: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize"
+  #     tokenURL: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token"
+  #     clientID: "$ENV:LKE_OAUTH2_CLIENT_ID"
+  #     clientSecret: "$ENV:LKE_OAUTH2_CLIENT_SECRET"
+  #     azure:
+  #       tenantID: "$ENV:LKE_OAUTH2_AZURE_TENANT_ID"
+  #     ## -- OpenID Connect example (generic provider):
+  #     # openidconnect:
+  #     #   userinfoURL: "https://provider.example.com/oidc/me"
+  #     #   scope: "openid profile email groups"
+  #     #   groupClaim: groups
+  #   ## -- Map external SSO groups to LKE roles (group ID or name → role):
+  #   externalUsersGroupMapping:
+  #     admin: 1
+  #     read: read
+  #     read-write: read and edit
+  #   ## -- Feature flag overrides for restricted tiers:
+  #   # enableCustomGroups: false
+  #   # enablePropertyKeyAccessRights: false
+  #   # guestMode: false
+  ## -- Uncomment to configure the MySQL database connection:
+  # db:
+  #   name: 'linkurious-{{ printf "%s" .Release.Name }}'
+  #   username: "$ENV:LKE_DB_USERNAME"
+  #   password: "$ENV:LKE_DB_PASSWORD"
+  #   options:
+  #     dialect: mysql
+  #     host: "$ENV:LKE_DB_HOST"
+  #     port: "$ENV-NUMBER:LKE_DB_PORT"
+  #     storage: "$UNSET"
+  #     dialectOptions:
+  #       ssl:
+  #         require: true
+  #         rejectUnauthorized: false
+  ## -- Uncomment to declare graph database data sources:
+  # dataSources:
+  #   - name: "My Neo4j Database"
+  #     sourceKey: "neo4j00"
+  #     graphdb:
+  #       vendor: neo4j
+  #       url: "$ENV:LKE_GRAPHDB_URL"
+  #       user: "$ENV:LKE_GRAPHDB_USER"
+  #       password: "$ENV:LKE_GRAPHDB_PASSWORD"
+  #       databaseName: "neo4j"
+  #       alternativeNodeId: uid
+  #       alternativeEdgeId: uid
+  #     index:
+  #       vendor: neo4jSearch
+  ## -- Uncomment to enable obfuscation of sensitive data in the UI:
+  # advanced:
+  #   obfuscation: true
+  ## -- Uncomment to add basemap tile layers (Leaflet):
+  # leaflet:
+  #   - name: OpenStreetMap
+  #     thumbnail: /assets/img/OpenStreetMap.png
+  #     urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+  #     attribution: '© <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+  #     subdomains: null
+  #     id: null
+  #     accessToken: null
+  #     minZoom: 2
+  #     maxZoom: 19
+  ## -- Uncomment to restrict features for trial / external-facing tiers:
+  # config:
+  #   hide: true
+  # alerts:
+  #   enabled: false
+  # entityResolution:
+  #   enabled: false
+  #   url: "https://er.linkurious.net"
+  # emailNotifications:
+  #   visualizationNotifications: true
+  # embeddedElasticSearch:
+  #   enabled: false
+  # license:
+  #   readOnly: true
+  # troubleshooting:
+  #   enableReport: false
+  #   enableFullErrors: false
+  # webhooks:
+  #   enabled: false
+  ## -- Uncomment to configure plugins (csv-importer, data-table, image-export, etc.):
+  # plugins:
+  #   csv-importer:
+  #     - {}
+  #   data-table:
+  #     - basePath: my-dataset
+  #       entityType: node
+  #       itemType: MY_NODE_TYPE
+  #       properties:
+  #         - id
+  #         - name
+  #   image-export:
+  #     - {}
+  #   plugin-manager:
+  #     - {}
   ## -- Uncomment to set the externally facing base URL (required for SSO):
   # url: https://lke.example.com
 


### PR DESCRIPTION
Add comprehensive commented-out documentation to the `config:` section of `values.yaml`, covering patterns observed in production instances (`lke-managed-instances`).

## What's added

All examples are commented out and serve as documentation only — no behaviour change.

- `instanceKey` — namespace/release-name pattern
- `server` — domain, publicPortHttps, forcePublicHttps, cookieSecure, allowOrigin (with templated wildcard), trustedReverseProxies, customHTTPHeaders
- `access` — disableLocalAuth, OAuth2 (Azure + OpenID Connect), externalUsersGroupMapping, feature flag overrides
- `db` — MySQL connection with `$ENV:` vars and SSL options
- `dataSources` — Neo4j data source with `$ENV:` vars, alternativeNodeId/EdgeId
- `advanced` — obfuscation
- `leaflet` — OpenStreetMap basemap tile layer
- Tier restrictions — config.hide, alerts, entityResolution, emailNotifications, embeddedElasticSearch, license.readOnly, troubleshooting, webhooks
- `plugins` — csv-importer, data-table, image-export, plugin-manager

Secrets use `$ENV:` variable expansion; non-secret config uses literal values.